### PR TITLE
sys: read and list sebools

### DIFF
--- a/src/sys.rs
+++ b/src/sys.rs
@@ -2,7 +2,7 @@
 
 use super::errors::{self, ResultExt};
 use openat;
-use std::{fs, path};
+use std::{collections, fs, io, path};
 
 use std::io::Read;
 use std::os::unix::io::{FromRawFd, IntoRawFd};
@@ -104,5 +104,80 @@ impl SELinuxFs {
         fp.read_to_string(&mut val)?;
         val.parse()
             .chain_err(|| "failed to parse policy version integer")
+    }
+
+    /// Return the value of the named SELinux booleans, if it exists.
+    ///
+    /// First value is the current state, while the second is the
+    /// value pending a commit.
+    pub fn sebool<T: AsRef<str>>(&self, name: T) -> errors::Result<Option<(bool, bool)>> {
+        let booldir = self.dirfd.sub_dir("booleans")?;
+        let target_bool = booldir.open_file(name.as_ref());
+
+        // Check that the sebool exists.
+        if let Err(ref e) = target_bool {
+            if e.kind() == io::ErrorKind::NotFound {
+                return Ok(None);
+            }
+        }
+
+        // Check that the sebool is a file.
+        let mut boolfile = target_bool?;
+        if !boolfile.metadata()?.is_file() {
+            return Ok(None);
+        }
+
+        // Read current and pending values (whitespace separated).
+        let mut buf = vec![0; 3];
+        boolfile.read_exact(&mut buf)?;
+        let cur = match buf.get(0) {
+            Some(b'0') => false,
+            Some(b'1') => true,
+            _ => bail!("unable to detect sebool current value"),
+        };
+        let next = match buf.get(2) {
+            Some(b'0') => false,
+            Some(b'1') => true,
+            _ => bail!("unable to detect sebool pending value"),
+        };
+
+        Ok(Some((cur, next)))
+    }
+
+    /// Return a map of all available SELinux booleans.
+    ///
+    /// First value is the current state, while the second is the
+    /// value pending a commit.
+    pub fn dump_sebools(&self) -> errors::Result<collections::BTreeMap<String, (bool, bool)>> {
+        let mut boolmap = collections::BTreeMap::new();
+        let sebools = self.list_sebools()?;
+        for name in sebools {
+            let vals = self.sebool(&name)?;
+            match vals {
+                Some(bb) => boolmap.insert(name, bb),
+                None => bail!("failed to get value for sebool {}", name),
+            };
+        }
+        Ok(boolmap)
+    }
+
+    /// Return a list of all available SELinux booleans names.
+    pub fn list_sebools(&self) -> errors::Result<collections::BTreeSet<String>> {
+        let mut boolset = collections::BTreeSet::new();
+        let booldir = self.dirfd.list_dir("booleans")?;
+        for entry in booldir {
+            // Ignore unavailable entries.
+            let bfile = match entry {
+                Ok(f) => f,
+                _ => continue,
+            };
+            // Ignore non-file entries.
+            let ftype = bfile.simple_type().unwrap_or(openat::SimpleType::Other);
+            if ftype != openat::SimpleType::File {
+                continue;
+            }
+            boolset.insert(bfile.file_name().to_string_lossy().into_owned());
+        }
+        Ok(boolset)
     }
 }

--- a/tests/sys-sebools.rs
+++ b/tests/sys-sebools.rs
@@ -1,0 +1,27 @@
+extern crate selinur;
+
+use selinur::sys;
+use std::{io};
+
+use std::io::Write;
+
+#[test]
+fn test_sys_sebools_list() {
+    if !has_selinuxfs() {
+        return;
+    }
+
+    let sefs = sys::SELinuxFs::open_path(sys::DEFAULT_PATH).unwrap();
+    let bools = sefs.list_sebools().unwrap();
+    // NOTE(lucab): this is a strong assumption, but not guaranteed.
+    assert!(bools.len() > 0);
+}
+
+fn has_selinuxfs() -> bool {
+    let ok = selinur::has_selinuxfs(None).unwrap_or(false);
+    if !ok {
+        let out = io::stdout();
+        writeln!(out.lock(), "selinuxfs not available, skipping.").ok();
+    }
+    ok
+}


### PR DESCRIPTION
This adds support for reading and listing the set of SELinux booleans
on a system where selinuxfs is available.